### PR TITLE
Add redirect rules for the other domains

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,7 +1,19 @@
 [[redirects]]
+  from = "https://runner.code-reading.org/*"
+  to = "https://runner.codereading.club/:splat"
+  status = 301
+  force = true
+
+[[redirects]]
+  from = "https://code-reading-runner.netlify.app/*"
+  to = "https://runner.codereading.club/:splat"
+  status = 301
+  force = true
+
+[[redirects]]
   from = "/*"
   to = "https://runner.codereading.club/index.html"
-  status = 301
+  status = 200
 
 [build]
   publish = "dist"


### PR DESCRIPTION
The same site is currently accessible in three domains:

- code-reading-runner.netlify.app
- runner.code-reading.org
- runner.codereading.club

We want a 301 redirect from the first two to the third. This would replace the url in the browser to the new domain.

But we also want a 200 redirect to index.html (which won't change the url that's displayed in the browser) because this is a single page application.

This commit adds two 301 redirects from the other domains to the one we want (runner.codereading.club).

Notice the `force = true` lines in the 301 redirect: according to Netlify's docs they determine "Whether to override any existing content in the path or not".
So even if we go to old-domain/index.html (which is a file that exists in the build directory) it would still follow the redirect rule.
We don't want this `force = true` on the 200 redirect because we need the css files and whatnot to be served as usual.